### PR TITLE
PropertyData can now be obtained with MethodBackedPropertyValue too

### DIFF
--- a/src/main/kotlin/gg/essential/vigilance/data/PropertyCollector.kt
+++ b/src/main/kotlin/gg/essential/vigilance/data/PropertyCollector.kt
@@ -21,7 +21,8 @@ abstract class PropertyCollector {
 
     internal fun getProperty(propertyName: String): PropertyData? = collectedProperties.firstOrNull {
         it.value is FieldBackedPropertyValue && it.value.field.name == propertyName ||
-        it.value is KPropertyBackedPropertyValue<*> && it.value.property.name == propertyName
+        it.value is KPropertyBackedPropertyValue<*> && it.value.property.name == propertyName ||
+        it.value is MethodBackedPropertyValue && it.value.method.name == propertyName
     }
 
     internal fun getProperty(field: Field): PropertyData? = collectedProperties.firstOrNull {

--- a/src/main/kotlin/gg/essential/vigilance/data/PropertyData.kt
+++ b/src/main/kotlin/gg/essential/vigilance/data/PropertyData.kt
@@ -132,7 +132,7 @@ abstract class CallablePropertyValue : PropertyValue() {
     abstract operator fun invoke(instance: Vigilant)
 }
 
-class MethodBackedPropertyValue(private val method: Method) : CallablePropertyValue() {
+class MethodBackedPropertyValue(internal val method: Method) : CallablePropertyValue() {
     override fun invoke(instance: Vigilant) {
         method.invoke(instance)
     }


### PR DESCRIPTION
Addition to PR #23 

Adds support for MethodBackedPropertyValues.
MethodBackedPropertyValues are used as property values for buttons when annotating a method with Property