### PR TITLE
Add custom dependencies

### DIFF
--- a/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
@@ -142,8 +142,36 @@ abstract class Vigilant @JvmOverloads constructor(
             error("Dependency must be a boolean PropertyType!")
         }
 
-        property.dependsOn = dependency
+        property.dependsOn = { dependency.getAsBoolean() }
         dependency.hasDependants = true
+    }
+
+    /**
+     * If the dependency is based on another property, make sure to also call setAsDependency
+     */
+    fun addCustomDependency(dependingPropertyName: String, stateProvider: () -> Boolean) {
+        propertyCollector.getProperty(dependingPropertyName)!!.dependsOn = stateProvider
+    }
+
+    /**
+     * If the dependency is based on another property, make sure to also call setAsDependency
+     */
+    fun addCustomDependency(dependingField: Field, stateProvider: () -> Boolean) {
+        propertyCollector.getProperty(dependingField)!!.dependsOn = stateProvider
+    }
+
+    /**
+     * Should be used when a property has a custom dependency based on this property
+     */
+    fun setAsDependency(dependencyPropertyName: String) {
+        propertyCollector.getProperty(dependencyPropertyName)!!.hasDependants = true
+    }
+
+    /**
+     * Should be used when a property has a custom dependency based on this property
+     */
+    fun setAsDependency(dependencyField: Field) {
+        propertyCollector.getProperty(dependencyField)!!.hasDependants = true
     }
 
     @Deprecated(

--- a/src/main/kotlin/gg/essential/vigilance/data/PropertyData.kt
+++ b/src/main/kotlin/gg/essential/vigilance/data/PropertyData.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KMutableProperty0
 
 data class PropertyData(val attributes: PropertyAttributes, val value: PropertyValue, val instance: Vigilant) {
     var action: ((Any?) -> Unit)? = null
-    var dependsOn: PropertyData? = null
+    var dependsOn: (() -> Boolean)? = null
     var hasDependants: Boolean = false
 
     fun getDataType() = attributes.type
@@ -23,7 +23,7 @@ data class PropertyData(val attributes: PropertyAttributes, val value: PropertyV
 
     fun <T> getAs(clazz: Class<T>) = clazz.cast(getAsAny())
 
-    fun isHidden(): Boolean = if (dependsOn == null) false else !dependsOn!!.getAsBoolean()
+    fun isHidden(): Boolean = if (dependsOn == null) false else !dependsOn!!()
 
     fun setValue(value: Any?) {
         if (value == null) {


### PR DESCRIPTION
I asked for opinions about this concept earlier in the Discord server, but got no response. I decided to open a PR, so this doesn't get missed/forgotten. I am open to suggestions on this.

Short explaination about what this PR adds:
Dependencies don't have to be based on boolean property states. Dependencies can be based on any function that returns a boolean. Properties may depend on a specific state of another property (not limited to boolean values). They can also depend on a completely external thing that isn't even a part of the config.

From the perspective of a mod dev, the changes in this PR don't change the behavior or usage of normal boolean property based dependencies, and instead just adds more options for making dependencies. However there are some changes under the hood.


A practical use case for this:
In a config I am developing, I want to have a (dropdown) selector that chooses one mode for an animation. After that config property, I would like to have settings relevant to that selected mode. In other words, I want to hide all settings that aren't related to the selected mode.

I could set the mode-specific settings to depend on the mode chooser, but the issue is that normally Vigilance dependencies only support boolean properties (a selector isn't one of them, because there can be more than 2 options) as the dependencies.

With something like the changes in this PR, I could specify the conditions when to display a property based on whatever I want.