### PR TITLE
Add support for localization of all display strings

### DIFF
--- a/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
@@ -192,16 +192,16 @@ abstract class Vigilant @JvmOverloads constructor(
     fun getCategories(): List<Category> {
         return propertyCollector.getProperties()
             .filter { !it.attributesExt.hidden }
-            .groupBy { it.attributesExt.category }
-            .map { Category(it.key, it.value.splitBySubcategory(), categoryDescription[it.key]?.description) }
+            .groupBy { it.attributesExt.localizedCategory to it.attributesExt.category }
+            .map { Category(it.key.first, it.value.splitBySubcategory(), categoryDescription[it.key.second]?.description?.let { desc -> I18n.format(desc) }) }
             .sortedWith(sortingBehavior.getCategoryComparator())
     }
 
     fun getCategoryFromSearch(term: String): Category {
         val sorted = propertyCollector.getProperties()
             .filter {
-                !it.attributesExt.hidden && (it.attributesExt.name.contains(term, ignoreCase = true) || it.attributesExt.description
-                    .contains(term, ignoreCase = true) || it.attributesExt.searchTags.any { str -> str.contains(term, ignoreCase = true) })
+                !it.attributesExt.hidden && (it.attributesExt.localizedName.contains(term, ignoreCase = true) || it.attributesExt.localizedDescription
+                    .contains(term, ignoreCase = true) || it.attributesExt.localizedSearchTags.any { str -> str.contains(term, ignoreCase = true) })
             }
             .sortedWith(sortingBehavior.getPropertyComparator())
 
@@ -275,11 +275,11 @@ abstract class Vigilant @JvmOverloads constructor(
         val withDividers = mutableListOf<CategoryItem>()
 
         items.forEachIndexed { index, (subcategoryName, listOfProperties) ->
-            val subcategoryInfo = categoryDescription[listOfProperties[0].attributesExt.category]?.subcategoryDescriptions?.get(subcategoryName)
+            val subcategoryInfo = categoryDescription[listOfProperties[0].attributesExt.category]?.subcategoryDescriptions?.get(subcategoryName)?.let { I18n.format(it) }
             if (index > 0 || subcategoryName.isNotBlank() || !subcategoryInfo.isNullOrBlank()) {
-                withDividers.add(DividerItem(subcategoryName, subcategoryInfo))
+                withDividers.add(DividerItem(I18n.format(subcategoryName), subcategoryInfo))
             }
-            withDividers.addAll(listOfProperties.sortedWith(sortingBehavior.getPropertyComparator()).map { PropertyItem(it, it.attributesExt.subcategory) })
+            withDividers.addAll(listOfProperties.sortedWith(sortingBehavior.getPropertyComparator()).map { PropertyItem(it, it.attributesExt.localizedSubcategory) })
         }
 
         return withDividers
@@ -343,10 +343,10 @@ abstract class Vigilant @JvmOverloads constructor(
             val data = PropertyData(
                 PropertyAttributes(
                     type,
-                    I18n.format(name),
-                    I18n.format(category),
-                    I18n.format(subcategory),
-                    I18n.format(description),
+                    name,
+                    category,
+                    subcategory,
+                    description,
                     min,
                     max,
                     minF,

--- a/src/main/kotlin/gg/essential/vigilance/data/Property.kt
+++ b/src/main/kotlin/gg/essential/vigilance/data/Property.kt
@@ -8,8 +8,11 @@ import java.util.*
 annotation class Property(
     val type: PropertyType,
     val name: String,
+    val i18nName: String = "",
     val category: String,
+    val i18nCategory: String = "",
     val subcategory: String = "",
+    val i18nSubcategory: String = "",
     val description: String = "",
     /**
      * Reserved for [PropertyType.SLIDER] and [PropertyType.NUMBER]
@@ -210,7 +213,11 @@ class PropertyAttributesExt @JvmOverloads constructor(
     /**
      * Search tags to help lost users
      */
-    val searchTags: List<String> = listOf()
+    val searchTags: List<String> = listOf(),
+
+    private val i18nName: String = name,
+    private val i18nCategory: String = category,
+    private val i18nSubcategory: String = subcategory
 ) {
     constructor(propertyAttributes: PropertyAttributes) : this(
         propertyAttributes.type,
@@ -232,6 +239,16 @@ class PropertyAttributesExt @JvmOverloads constructor(
         propertyAttributes.hidden,
         listOf()
     )
+
+    internal val localizedName get() = I18n.format(i18nName)
+
+    internal val localizedCategory get() = I18n.format(i18nCategory)
+
+    internal val localizedSubcategory get() = I18n.format(i18nSubcategory)
+
+    internal val localizedDescription get() = I18n.format(description)
+
+    internal val localizedSearchTags get() = searchTags.map { I18n.format(it) }
 
     companion object {
         fun fromPropertyAnnotation(property: Property): PropertyAttributesExt {
@@ -257,7 +274,10 @@ class PropertyAttributesExt @JvmOverloads constructor(
                     property.searchTags
                 } catch (e: AbstractMethodError) {
                     emptyArray()
-                }.toList()
+                }.toList(),
+                property.i18nName.ifEmpty { property.name },
+                property.i18nCategory.ifEmpty { property.category },
+                property.i18nSubcategory.ifEmpty { property.subcategory }
             )
         }
     }

--- a/src/main/kotlin/gg/essential/vigilance/data/Property.kt
+++ b/src/main/kotlin/gg/essential/vigilance/data/Property.kt
@@ -270,18 +270,21 @@ class PropertyAttributesExt @JvmOverloads constructor(
                 property.protectedText,
                 property.triggerActionOnInitialization,
                 property.hidden,
-                try {
-                    property.searchTags
-                } catch (e: AbstractMethodError) {
-                    emptyArray()
-                }.toList(),
-                property.i18nName.ifEmpty { property.name },
-                property.i18nCategory.ifEmpty { property.category },
-                property.i18nSubcategory.ifEmpty { property.subcategory }
+                property.safeGet(emptyArray()) { searchTags }.toList(),
+                property.safeGet("") { i18nName }.ifEmpty { property.name },
+                property.safeGet("") { i18nCategory }.ifEmpty { property.category },
+                property.safeGet("") { i18nSubcategory }.ifEmpty { property.subcategory }
             )
         }
     }
 }
+
+private inline fun <T> Property.safeGet(default: T, getter: Property.() -> T) =
+    try {
+        getter()
+    } catch (e: AbstractMethodError) {
+        default
+    }
 
 fun PropertyAttributesExt.toPropertyAttributes(): PropertyAttributes =
     PropertyAttributes(

--- a/src/main/kotlin/gg/essential/vigilance/example/ExampleConfig.kt
+++ b/src/main/kotlin/gg/essential/vigilance/example/ExampleConfig.kt
@@ -18,15 +18,16 @@ import kotlin.math.PI
 object ExampleConfig : Vigilant(File("./config/example.toml")) {
     @Property(
         type = PropertyType.CHECKBOX,
-        name = "Checkbox",
-        description = "This is a checkbox property. It stores a boolean value.",
-        category = "Property Overview"
+        name = "menu.singleplayer",
+        description = "options.sounds.title",
+        category = "options.sounds.title"
     )
     var demoCheckbox = true
 
     @Property(
         type = PropertyType.SWITCH,
         name = "Switch",
+        i18nName = "menu.multiplayer",
         description = "This is a switch property. It stores a boolean value.",
         category = "Property Overview"
     )
@@ -35,8 +36,8 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
     @Property(
         type = PropertyType.TEXT,
         name = "Text",
-        description = "This is a text property. It stores a single line of continuous text.",
-        category = "Property Overview"
+        description = "options.sounds.title",
+        category = "options.sounds.title"
     )
     var demoText = ""
 
@@ -100,7 +101,7 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
         name = "Selector",
         description = "This is a selector property. It stores a specific item in a list of strings. The property will store the index of the list, not the string.",
         category = "Property Overview",
-        options = ["Option 1", "Option 2", "Option 3"]
+        options = ["options.sounds.title", "options.sounds.title", "options.sounds.title"]
     )
     var demoSelector = 0
 
@@ -126,8 +127,8 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
         type = PropertyType.SWITCH,
         name = "Property Pete",
         description = "",
-        category = "Property Overview",
-        subcategory = "Subcategory Steve"
+        category = "options.sounds.title",
+        subcategory = "options.sounds.title"
     )
     var propertyPete = true
 
@@ -457,7 +458,7 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
         type = PropertyType.BUTTON,
         name = "Button with text",
         description = "A button that has a custom placeholder, giving it different text",
-        placeholder = "Click Me!",
+        placeholder = "options.sounds.title",
         category = "Property Deep-Dive",
         subcategory = "Buttons"
     )
@@ -536,8 +537,8 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
         hidePropertyIf("linuxOnlyProperty") { !os.contains("linux") }
 
         setCategoryDescription(
-            "Property Overview",
-            "This category is a quick overview of all of the components. For a deep-dive into the component, check their specific subcategories."
+            "options.sounds.title",
+            "options.sounds.title"
         )
 
         setCategoryDescription(
@@ -546,9 +547,9 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
         )
 
         setSubcategoryDescription(
-            "Property Deep-Dive",
-            "Buttons",
-            "Buttons are a great way for the user to run an action. Buttons don't have any associated state, and as such their annotation target has to be a method."
+            "options.sounds.title",
+            "options.sounds.title",
+            "menu.singleplayer"
         )
     }
 }

--- a/src/main/kotlin/gg/essential/vigilance/example/ExampleConfig.kt
+++ b/src/main/kotlin/gg/essential/vigilance/example/ExampleConfig.kt
@@ -18,16 +18,15 @@ import kotlin.math.PI
 object ExampleConfig : Vigilant(File("./config/example.toml")) {
     @Property(
         type = PropertyType.CHECKBOX,
-        name = "menu.singleplayer",
-        description = "options.sounds.title",
-        category = "options.sounds.title"
+        name = "Checkbox",
+        description = "This is a checkbox property. It stores a boolean value.",
+        category = "Property Overview"
     )
     var demoCheckbox = true
 
     @Property(
         type = PropertyType.SWITCH,
         name = "Switch",
-        i18nName = "menu.multiplayer",
         description = "This is a switch property. It stores a boolean value.",
         category = "Property Overview"
     )
@@ -36,8 +35,8 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
     @Property(
         type = PropertyType.TEXT,
         name = "Text",
-        description = "options.sounds.title",
-        category = "options.sounds.title"
+        description = "This is a text property. It stores a single line of continuous text.",
+        category = "Property Overview"
     )
     var demoText = ""
 
@@ -101,7 +100,7 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
         name = "Selector",
         description = "This is a selector property. It stores a specific item in a list of strings. The property will store the index of the list, not the string.",
         category = "Property Overview",
-        options = ["options.sounds.title", "options.sounds.title", "options.sounds.title"]
+        options = ["Option 1", "Option 2", "Option 3"]
     )
     var demoSelector = 0
 
@@ -127,8 +126,8 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
         type = PropertyType.SWITCH,
         name = "Property Pete",
         description = "",
-        category = "options.sounds.title",
-        subcategory = "options.sounds.title"
+        category = "Property Overview",
+        subcategory = "Subcategory Steve"
     )
     var propertyPete = true
 
@@ -458,7 +457,7 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
         type = PropertyType.BUTTON,
         name = "Button with text",
         description = "A button that has a custom placeholder, giving it different text",
-        placeholder = "options.sounds.title",
+        placeholder = "Click Me!",
         category = "Property Deep-Dive",
         subcategory = "Buttons"
     )
@@ -537,8 +536,8 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
         hidePropertyIf("linuxOnlyProperty") { !os.contains("linux") }
 
         setCategoryDescription(
-            "options.sounds.title",
-            "options.sounds.title"
+            "Property Overview",
+            "This category is a quick overview of all of the components. For a deep-dive into the component, check their specific subcategories."
         )
 
         setCategoryDescription(
@@ -547,9 +546,9 @@ object ExampleConfig : Vigilant(File("./config/example.toml")) {
         )
 
         setSubcategoryDescription(
-            "options.sounds.title",
-            "options.sounds.title",
-            "menu.singleplayer"
+            "Property Deep-Dive",
+            "Buttons",
+            "Buttons are a great way for the user to run an action. Buttons don't have any associated state, and as such their annotation target has to be a method."
         )
     }
 }

--- a/src/main/kotlin/gg/essential/vigilance/gui/DataBackedSetting.kt
+++ b/src/main/kotlin/gg/essential/vigilance/gui/DataBackedSetting.kt
@@ -33,7 +33,7 @@ class DataBackedSetting(internal val data: PropertyData, internal val component:
         height = ChildBasedSizeConstraint(3f) + INNER_PADDING.pixels()
     } childOf boundingBox
 
-    private val settingName by UIWrappedText(data.attributesExt.name).constrain {
+    private val settingName by UIWrappedText(data.attributesExt.localizedName).constrain {
         width = RelativeConstraint(1f)
         textScale = 1.49f.pixels()
         color = VigilancePalette.brightTextState.toConstraint()
@@ -41,7 +41,7 @@ class DataBackedSetting(internal val data: PropertyData, internal val component:
     } childOf textBoundingBox
 
     init {
-        UIWrappedText(data.attributesExt.description).constrain {
+        UIWrappedText(data.attributesExt.localizedDescription).constrain {
             y = SiblingConstraint() + 3.pixels()
             width = RelativeConstraint(1f)
             color = VigilancePalette.midTextState.toConstraint()


### PR DESCRIPTION
Does what it says on the tin. You can either use a localization key in place of the name, or specify a name and a localization key for backwards-compatibility with existing config files.