### PR TITLE
Vigilant: Separate data loading and Vigilance.initialize call

### DIFF
--- a/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
+++ b/src/main/kotlin/gg/essential/vigilance/Vigilant.kt
@@ -46,7 +46,10 @@ abstract class Vigilant @JvmOverloads constructor(
      */
     fun initialize() {
         Vigilance.initialize()
+        loadData()
+    }
 
+    fun loadData() {
         try {
             readData()
         } catch (e: Throwable) {


### PR DESCRIPTION
This change moves the data loading and timer creation into a separate method. In CT, our main config class is an instance of `Vigilant`, and it contains settings which are relevant to us at ASM injection time. We need to be able to initialize the data portion of our config class so we can access the current user settings. This is currently impossible as `Vigilant::initialize()` causes `StencilEffect::enableStencil` to be called, which classloads `Minecraft` and crashes the game. This change allows us to initialize the settings and delay enabling the `StencilEffect` until after ASM injection.

(function name bikeshedding is welcome, I didn't really know what to call it)