### PR TITLE
Build: Publish sources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,8 @@ tasks.test {
     useJUnitPlatform()
 }
 
+java.withSourcesJar()
+
 publishing.publications.named<MavenPublication>("maven") {
     artifactId = "vigilance"
 }


### PR DESCRIPTION
We used to publish these but accidentially stopped doing so with 2e881ee8.

Note: Fixup typo in commit hash when merging.